### PR TITLE
Add FormikPhoneField, FormikCurrencyField, and FormikRichTextField

### DIFF
--- a/.claude/skills/create-version-changeset/SKILL.md
+++ b/.claude/skills/create-version-changeset/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create-version-changeset
 description: Create a changeset for versioning and changelog generation.
+model: sonnet
 ---
 
 To create a changeset for versioning and changelog generation, follow these steps:

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "author": "Wadii Basmi",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wadiibasmi/formik-mui-fields.git"
+    "url": "git+https://github.com/wbasmi/formik-mui-fields.git"
   },
-  "homepage": "https://github.com/wadiibasmi/formik-mui-fields#readme",
+  "homepage": "https://github.com/wbasmi/formik-mui-fields#readme",
   "bugs": {
-    "url": "https://github.com/wadiibasmi/formik-mui-fields/issues"
+    "url": "https://github.com/wbasmi/formik-mui-fields/issues"
   },
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formik-mui-fields",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publishConfig": {
     "access": "public"
   },
@@ -87,6 +87,8 @@
     "@tiptap/extension-placeholder": "^3.21.0",
     "@tiptap/react": "^3.21.0",
     "@tiptap/starter-kit": "^3.21.0",
+    "country-codes-list": "^2.0.0",
+    "country-flag-icons": "^1.6.15",
     "react-color": "^2.19.3",
     "react-image-crop": "^11.0.10",
     "use-debounce": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
     "changeset:version": "changeset version"
   },
   "dependencies": {
+    "@tiptap/extension-link": "^3.21.0",
+    "@tiptap/extension-placeholder": "^3.21.0",
+    "@tiptap/react": "^3.21.0",
+    "@tiptap/starter-kit": "^3.21.0",
     "react-color": "^2.19.3",
     "react-image-crop": "^11.0.10",
     "use-debounce": "^10.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.21.0
         version: 3.21.0
+      country-codes-list:
+        specifier: ^2.0.0
+        version: 2.0.0
+      country-flag-icons:
+        specifier: ^1.6.15
+        version: 1.6.15
       formik:
         specifier: '>=2'
         version: 2.4.9(@types/react@19.2.14)(react@19.2.4)
@@ -1588,6 +1594,12 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  country-codes-list@2.0.0:
+    resolution: {integrity: sha512-KZqq/LBdCD76hQCa6nOx0bA/nIjYly1OtV8+Bbt/4SW+mJEqGk7oZHjUj7PRrV0gXJJKs6Tv2cIntFdofBByvA==}
+
+  country-flag-icons@1.6.15:
+    resolution: {integrity: sha512-92HoA8l6DluEidku8tKBftjuFRj4Rv3zDW1lXxCuNnqAxhUSkvso9gM/Afj4F5BnK+wneHIe3ydI+s+4NA29/Q==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -4550,6 +4562,10 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.3
+
+  country-codes-list@2.0.0: {}
+
+  country-flag-icons@1.6.15: {}
 
   crelt@1.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@mui/material':
         specifier: '>=7'
         version: 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tiptap/extension-link':
+        specifier: ^3.21.0
+        version: 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-placeholder':
+        specifier: ^3.21.0
+        version: 3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/react':
+        specifier: ^3.21.0
+        version: 3.21.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tiptap/starter-kit':
+        specifier: ^3.21.0
+        version: 3.21.0
       formik:
         specifier: '>=2'
         version: 2.4.9(@types/react@19.2.14)(react@19.2.4)
@@ -68,7 +80,7 @@ importers:
         version: 10.3.3(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.0)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@7.3.1(@types/node@20.19.37))
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -545,6 +557,15 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -766,6 +787,9 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1025,6 +1049,160 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tiptap/core@3.21.0':
+    resolution: {integrity: sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ==}
+    peerDependencies:
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-blockquote@3.21.0':
+    resolution: {integrity: sha512-JDM/RR6rM0dMCZ1UnEf7eqmN6pAdIa2llhN+E24HdTGNJCklMFhLAGE/OT8/1r7M0WWA9GVO7/PTe4EdGh6+lQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-bold@3.21.0':
+    resolution: {integrity: sha512-iyEJRzG7XTCPlHwEDzUw3HnuYYCfL7lNpcCHmxcpYMrIUA8rv7EUxerIwApT6xY8hQ/07ljuJKgOyPvnJOOzuA==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-bubble-menu@3.21.0':
+    resolution: {integrity: sha512-/fabRRhhf8i4LAx9e8xz9ppqN5KgdJk3TxMuxAD5vAWGsejvhSoPa8O8H/QwwyntXm1Vue8aQiMHsUk48b2hGQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-bullet-list@3.21.0':
+    resolution: {integrity: sha512-PWNF+xwxgOeXYGD88sCQLKL0eBoQqjUnZNALxBjN3Y7x4llalh42rHOp2Nt2t6UbQgqTBtBzU/uFcussTpxreQ==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.21.0
+
+  '@tiptap/extension-code-block@3.21.0':
+    resolution: {integrity: sha512-zrVOcOzDCjHQ8NJcC+qHmZZKiwnP/NMSb3qVJlSMN8TzuHept1MZCDa2Mbo70O6I0txo456SGuXB9sqV1vHmGg==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-code@3.21.0':
+    resolution: {integrity: sha512-D7wA9jp+4X2r1f3FIoga73s6Rn4rmZY57Jes6a4rK3HY+3yHk1r057pPIZSY8Drfs97jxHQVFdfUYUomLSFYBA==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-document@3.21.0':
+    resolution: {integrity: sha512-7oCyzXI9ChvJQUlr23AURdfVar4OIsrYUvqdhEwo3bjcI/Q/j0KJiXfuh6ZzL5eVaINSailH53sZaGg4THQtUg==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-dropcursor@3.21.0':
+    resolution: {integrity: sha512-6fsDSVAM2iz7eElvT6iivMrGBGjIP/oPigVZ/SPm6f31phaYhz6TIOEgV/Lr2jaPIOgyK4U0cU4Yd4KUBCmhzQ==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.21.0
+
+  '@tiptap/extension-floating-menu@3.21.0':
+    resolution: {integrity: sha512-n2HzTB+I/5rAl8R/1sKMv92JiY1oDK1hroXizxEKYa6dskJcAMW0CfYyPcPOZWQQEe7qoeOvQISr2ooLAKW+Mw==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-gapcursor@3.21.0':
+    resolution: {integrity: sha512-wGjgAoYBTvPAe9QYMI5px355XcNeMkaUrMY9IHbMqgqdmHcDxqooxM4H6sYVX2CRcHwXy4I8NQAoOhSYrQJDMg==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.21.0
+
+  '@tiptap/extension-hard-break@3.21.0':
+    resolution: {integrity: sha512-6JFVSAOQ1qhQHi9mVcdn2/XO8YIMgYV8zjarzNUzP6Sf2waeE5BLXjlg6rIH/945sY1J+FndTojLru6gQ07a5A==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-heading@3.21.0':
+    resolution: {integrity: sha512-ji6VJmoRnDzAHYflEYEZohMHRi77UGLW1o3ua7UhI32iJ9nuYssbPNuzEeE4SvENMQwZRszad5+a+dKAa+NC7g==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-horizontal-rule@3.21.0':
+    resolution: {integrity: sha512-vNBnOfFEY62CoJPGo4nonRM7RiOvhII1vhoO+WFr1GxDqCAfmEFjToflt7JT1UJdo6lMVcD+aaaAgOiuSz5p6g==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-italic@3.21.0':
+    resolution: {integrity: sha512-2I8oPvwyXhRn1k8lbDFIutzvhtLEjoO5mmQCNX4TnT4PdxxaSrK9+ihYg12VeqhUeO7dg1MKiFqws0HVBrwzWg==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-link@3.21.0':
+    resolution: {integrity: sha512-oMU7Yve1sbgBsaFAUc2R0GPf4d3ZPVJeMUFC6b6X9rJIvx/IhEUEn9toQcSBGfp02uWK9NdQyIFYFdWlVXH++w==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-list-item@3.21.0':
+    resolution: {integrity: sha512-1ZymZmlQVbAoC4q5x3cro0v5+3I6l+BHqbhIMQLjQFlAOJfcE0pvqRzAFW7PduxUj41tXEtsYqp2NREvO9F5Fg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.21.0
+
+  '@tiptap/extension-list-keymap@3.21.0':
+    resolution: {integrity: sha512-EzrfW3ASNFPWKhR8sNOq7Kqw4hvaTAOn4dlI7chB8HIANSrlyPOUn+eKAnO6HQgsUgsbjg2GbTUrGrxcoLykUg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.21.0
+
+  '@tiptap/extension-list@3.21.0':
+    resolution: {integrity: sha512-KeBlEtLrGce2d3dgL89hmwWEtREuzlW4XY5bYWpKNvCbFqvdSb3n7vkdkw32YclZmMWxAcABgW6ucCStkE0rsQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/extension-ordered-list@3.21.0':
+    resolution: {integrity: sha512-+d+0orokMfqaBfvr9tUBgGvo2ZCV+fR3JzsJTmnLBWOkhBSJN7H4pnfXPTue0qwspUwRmkLJxdIlU+J7HkMrng==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.21.0
+
+  '@tiptap/extension-paragraph@3.21.0':
+    resolution: {integrity: sha512-cMPG/jCoZ9NmLZ5ctFziILaxJGfDtMTb5OLBhifMFZeMVwF1pEJIygDEfnX/HSruv507weZSQG4pERO2tRszMg==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-placeholder@3.21.0':
+    resolution: {integrity: sha512-fs+cQqMh1d1naV6OgOhP/0qbRJwtw8DpQMj3/oqGKbaRRKIeecEaZPXYRd7MYa4e9K0Cfk5Bm0MNs9lwu/BYsw==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.21.0
+
+  '@tiptap/extension-strike@3.21.0':
+    resolution: {integrity: sha512-easnVaN11Wl+5fOtfvzJ10J762S9TRXZaMj5rLBGavgf82DCYHqhGhBqpLQrJ41r4nPABGlYvTRoxfvBLB74Lg==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-text@3.21.0':
+    resolution: {integrity: sha512-Zx8QdB8a5iBuE4uO21c3BjmpBfaJEr2Jd1QFnsdgx11fm6P7dGgZaGko1FaINhfOPRGTN6O/kiF02cDMdOHa/w==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extension-underline@3.21.0':
+    resolution: {integrity: sha512-gGmBEymbWnr8AIS8bI/bPw5rcwo7wAFcBw/TsLd1nAanu1dDqSRNDBrit3m02Ru+D88u2SfNvmbOPI1pz+1f5w==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+
+  '@tiptap/extensions@3.21.0':
+    resolution: {integrity: sha512-MN1uh5PmHT1F2BNsbc21MIS0AMFFA73oODlp/4ckpBR4o5AxRwV+8f43Cd52UL4MgMkKj/A+QfZ7iK9IDb0h5A==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+
+  '@tiptap/pm@3.21.0':
+    resolution: {integrity: sha512-I3sNo7oMMsR6FFz1ecvPb9uCF0VQuS2WV67j8Io2M7DJicRWCE/GM5DaiYjTeWBbnByk6BuG0txoJATAqPVliQ==}
+
+  '@tiptap/react@3.21.0':
+    resolution: {integrity: sha512-p+OKJgxmFB3t5nY3mjaqjKaj8vJX9++OkdrZLRxYuG7ScAHemWraWQ25sgNZl1LDaRYrdnNYxx9MP0CXOSB6ew==}
+    peerDependencies:
+      '@tiptap/core': ^3.21.0
+      '@tiptap/pm': ^3.21.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.21.0':
+    resolution: {integrity: sha512-w7fWxglDtqXFBgRYH+LforJyUboSAQllnWQbGVSTyX4rsICqZjkb3f6CTSUWpGoGKmlmbb2ZpEuoik7tur9d8Q==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1063,6 +1241,15 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
@@ -1083,6 +1270,11 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
@@ -1098,6 +1290,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -1394,6 +1589,9 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1485,6 +1683,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1583,6 +1785,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1885,6 +2091,12 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1937,8 +2149,15 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   material-colors@1.2.6:
     resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2008,6 +2227,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -2159,6 +2381,68 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  prosemirror-changeset@2.4.0:
+    resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-menu@1.3.0:
+    resolution: {integrity: sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.11.0:
+    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
+
+  prosemirror-view@1.41.7:
+    resolution: {integrity: sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2260,6 +2544,9 @@ packages:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -2517,6 +2804,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -2629,6 +2919,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -3199,6 +3492,20 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/utils@0.2.11':
+    optional: true
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3404,6 +3711,8 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@remirror/core-constants@3.0.0': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
     dependencies:
@@ -3620,7 +3929,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
@@ -3628,10 +3937,192 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tiptap/core@3.21.0(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/pm': 3.21.0
+
+  '@tiptap/extension-blockquote@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-bold@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-bubble-menu@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-code-block@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+
+  '@tiptap/extension-code@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-document@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-dropcursor@3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extensions': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-floating-menu@3.21.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extensions': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-hard-break@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-heading@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-horizontal-rule@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+
+  '@tiptap/extension-italic@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-link@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-list-keymap@3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+
+  '@tiptap/extension-ordered-list@3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-paragraph@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-placeholder@3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/extensions': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-strike@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-text@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extension-underline@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+
+  '@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+
+  '@tiptap/pm@3.21.0':
+    dependencies:
+      prosemirror-changeset: 2.4.0
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.4
+      prosemirror-menu: 1.3.0
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  '@tiptap/react@3.21.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-floating-menu': 3.21.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.21.0':
+    dependencies:
+      '@tiptap/core': 3.21.0(@tiptap/pm@3.21.0)
+      '@tiptap/extension-blockquote': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-bold': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-bullet-list': 3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-code': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-code-block': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-document': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-dropcursor': 3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-gapcursor': 3.21.0(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-hard-break': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-heading': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-horizontal-rule': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-italic': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-link': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-list': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/extension-list-item': 3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-list-keymap': 3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-ordered-list': 3.21.0(@tiptap/extension-list@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))
+      '@tiptap/extension-paragraph': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-strike': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-text': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extension-underline': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))
+      '@tiptap/extensions': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
+      '@tiptap/pm': 3.21.0
 
   '@types/aria-query@5.0.4': {}
 
@@ -3676,6 +4167,15 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/mdx@2.0.13': {}
 
   '@types/node@12.20.55': {}
@@ -3693,6 +4193,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/reactcss': 1.2.13(@types/react@19.2.14)
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3706,6 +4210,8 @@ snapshots:
       '@types/react': 19.2.14
 
   '@types/resolve@1.20.6': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)':
     dependencies:
@@ -4045,6 +4551,8 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
+  crelt@1.0.6: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4117,6 +4625,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -4251,6 +4761,8 @@ snapshots:
   extendable-error@0.1.7: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -4553,6 +5065,12 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.2: {}
+
   load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
@@ -4599,7 +5117,18 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   material-colors@1.2.6: {}
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -4664,6 +5193,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  orderedmap@2.1.1: {}
 
   outdent@0.5.0: {}
 
@@ -4782,6 +5313,111 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  prosemirror-changeset@2.4.0:
+    dependencies:
+      prosemirror-transform: 1.11.0
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+      prosemirror-model: 1.25.4
+
+  prosemirror-menu@1.3.0:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  prosemirror-transform@1.11.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.7:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -4918,6 +5554,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.0
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   rrweb-cssom@0.8.0: {}
 
@@ -5151,6 +5789,8 @@ snapshots:
 
   typescript@6.0.2: {}
 
+  uc.micro@2.1.0: {}
+
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
@@ -5224,6 +5864,8 @@ snapshots:
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/FormikCurrencyField/FormikCurrencyField.stories.tsx
+++ b/src/FormikCurrencyField/FormikCurrencyField.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withFormik } from "../test-utils/FormikDecorator";
+import FormikCurrencyField from "./FormikCurrencyField";
+
+const meta: Meta<typeof FormikCurrencyField> = {
+  title: "FormikCurrencyField",
+  component: FormikCurrencyField,
+  decorators: [
+    withFormik({
+      initialValues: { price: 1234.56, amount: 0 },
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FormikCurrencyField>;
+
+export const Default: Story = {
+  args: {
+    name: "price",
+    label: "Price",
+  },
+};
+
+export const Error: Story = {
+  decorators: [
+    withFormik({
+      initialValues: { price: null },
+      initialErrors: { price: "Price is required" },
+      initialTouched: { price: true },
+    }),
+  ],
+  args: {
+    name: "price",
+    label: "Price",
+  },
+};
+
+export const EUR: Story = {
+  decorators: [
+    withFormik({
+      initialValues: { price: 9999.99 },
+    }),
+  ],
+  args: {
+    name: "price",
+    label: "Price (EUR)",
+    currency: "EUR",
+    locale: "de-DE",
+  },
+};
+
+export const CustomPrecision: Story = {
+  decorators: [
+    withFormik({
+      initialValues: { price: 42.1234 },
+    }),
+  ],
+  args: {
+    name: "price",
+    label: "Price (4 decimals)",
+    decimalPlaces: 4,
+  },
+};

--- a/src/FormikCurrencyField/FormikCurrencyField.test.tsx
+++ b/src/FormikCurrencyField/FormikCurrencyField.test.tsx
@@ -1,0 +1,209 @@
+import { type Mock } from "vitest";
+import { render } from "@testing-library/react";
+import { useField } from "formik";
+import { InputAdornment, TextField } from "@mui/material";
+import FormikCurrencyField from "./FormikCurrencyField";
+
+vi.mock("formik", () => ({
+  useField: vi.fn(),
+}));
+
+vi.mock("@mui/material", () => ({
+  InputAdornment: vi.fn(({ children }: any) => children),
+  TextField: vi.fn(() => null),
+}));
+
+const mockUseField = useField as Mock;
+const MockTextField = TextField as unknown as Mock;
+const MockInputAdornment = InputAdornment as unknown as Mock;
+
+const mockHelpers = {
+  setValue: vi.fn(),
+  setTouched: vi.fn(),
+  setError: vi.fn(),
+};
+const defaultField = {
+  name: "price",
+  value: 1234.56,
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+};
+const defaultMeta = {
+  touched: false,
+  error: undefined,
+  initialTouched: false,
+  initialError: undefined,
+  initialValue: 1234.56,
+  value: 1234.56,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseField.mockReturnValue([defaultField, defaultMeta, mockHelpers]);
+});
+
+describe("FormikCurrencyField", () => {
+  describe("when rendered with a name", () => {
+    it("calls useField with the name", () => {
+      render(<FormikCurrencyField name="price" />);
+      expect(mockUseField).toHaveBeenCalledWith("price");
+    });
+  });
+
+  describe("when field has a numeric value", () => {
+    it("renders TextField with formatted display value", () => {
+      render(<FormikCurrencyField name="price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "price",
+          value: "1,234.56",
+        }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field value is null", () => {
+    it("renders TextField with empty string value", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: null },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikCurrencyField name="price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({ value: "" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field has no errors", () => {
+    it("renders TextField with error false and no helperText", () => {
+      render(<FormikCurrencyField name="price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: false,
+          helperText: undefined,
+        }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field is touched with an error", () => {
+    it("renders TextField with error true and the error message as helperText", () => {
+      mockUseField.mockReturnValue([
+        defaultField,
+        { ...defaultMeta, touched: true, error: "Required" },
+        mockHelpers,
+      ]);
+      render(<FormikCurrencyField name="price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: true,
+          helperText: "Required",
+        }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field is untouched with an error", () => {
+    it("renders TextField with error false", () => {
+      mockUseField.mockReturnValue([
+        defaultField,
+        { ...defaultMeta, touched: false, error: "Required" },
+        mockHelpers,
+      ]);
+      render(<FormikCurrencyField name="price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({ error: false }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when a label is provided", () => {
+    it("passes the label to TextField", () => {
+      render(<FormikCurrencyField name="price" label="Price" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({ label: "Price" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when additional props are passed", () => {
+    it("forwards them to TextField", () => {
+      render(
+        <FormikCurrencyField name="price" label="Price" variant="outlined" />,
+      );
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: "Price",
+          variant: "outlined",
+        }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when onChange is triggered", () => {
+    it("parses the input and calls setValue with a number", () => {
+      render(<FormikCurrencyField name="price" />);
+      const onChangeProp = MockTextField.mock.calls[0][0].onChange;
+      onChangeProp({ target: { value: "5,678.90" } });
+      expect(mockHelpers.setValue).toHaveBeenCalledWith(5678.9);
+    });
+
+    it("calls setValue with null for empty input", () => {
+      render(<FormikCurrencyField name="price" />);
+      const onChangeProp = MockTextField.mock.calls[0][0].onChange;
+      onChangeProp({ target: { value: "" } });
+      expect(mockHelpers.setValue).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("when onBlur is triggered", () => {
+    it("calls setTouched with true", () => {
+      render(<FormikCurrencyField name="price" />);
+      const onBlurProp = MockTextField.mock.calls[0][0].onBlur;
+      onBlurProp();
+      expect(mockHelpers.setTouched).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("when currency symbol is rendered", () => {
+    it("passes slotProps with startAdornment to TextField", () => {
+      render(<FormikCurrencyField name="price" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      expect(slotProps).toBeDefined();
+      expect(slotProps.input).toBeDefined();
+      expect(slotProps.input.startAdornment).toBeDefined();
+    });
+
+    it("renders InputAdornment in the startAdornment element", () => {
+      render(<FormikCurrencyField name="price" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const adornment = slotProps.input.startAdornment;
+      expect(adornment.type).toBe(MockInputAdornment);
+      expect(adornment.props.position).toBe("start");
+    });
+  });
+
+  describe("when custom decimalPlaces is provided", () => {
+    it("formats value with the specified precision", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: 42.1 },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikCurrencyField name="price" decimalPlaces={4} />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({ value: "42.1000" }),
+        undefined,
+      );
+    });
+  });
+});

--- a/src/FormikCurrencyField/FormikCurrencyField.tsx
+++ b/src/FormikCurrencyField/FormikCurrencyField.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { InputAdornment, TextField, type TextFieldProps } from "@mui/material";
+import { useField } from "formik";
+
+type Props = {
+  name: string;
+  label?: string;
+  currency?: string;
+  locale?: string;
+  decimalPlaces?: number;
+} & Omit<
+  TextFieldProps,
+  "name" | "value" | "onChange" | "onBlur" | "error" | "helperText"
+>;
+
+const getCurrencySymbol = (currency: string, locale: string): string => {
+  const formatted = new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    currencyDisplay: "narrowSymbol",
+  }).format(0);
+  return formatted.replace(/[\d.,\s]/g, "").trim();
+};
+
+const formatValue = (
+  value: number | null | undefined,
+  locale: string,
+  decimalPlaces: number,
+): string => {
+  if (value === null || value === undefined || isNaN(value)) return "";
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+    useGrouping: true,
+  }).format(value);
+};
+
+const parseValue = (input: string, locale: string): number | null => {
+  if (!input) return null;
+
+  const parts = new Intl.NumberFormat(locale).formatToParts(1234.56);
+  const groupSeparator = parts.find((p) => p.type === "group")?.value ?? ",";
+  const decimalSeparator =
+    parts.find((p) => p.type === "decimal")?.value ?? ".";
+
+  let cleaned = input;
+  cleaned = cleaned.split(groupSeparator).join("");
+  cleaned = cleaned.split(decimalSeparator).join(".");
+
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? null : num;
+};
+
+const FormikCurrencyField = ({
+  name,
+  label,
+  currency = "USD",
+  locale = "en-US",
+  decimalPlaces = 2,
+  ...props
+}: Props) => {
+  const [field, meta, helpers] = useField<number | null>(name);
+  const hasError = meta.touched && Boolean(meta.error);
+
+  const currencySymbol = getCurrencySymbol(currency, locale);
+  const displayValue = formatValue(field.value, locale, decimalPlaces);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    const parsed = parseValue(raw, locale);
+    helpers.setValue(parsed);
+  };
+
+  const handleBlur = () => {
+    helpers.setTouched(true);
+  };
+
+  return (
+    <TextField
+      {...props}
+      name={field.name}
+      label={label}
+      value={displayValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      error={hasError}
+      helperText={hasError ? meta.error : undefined}
+      slotProps={{
+        ...props.slotProps,
+        input: {
+          ...(typeof props.slotProps?.input === "object"
+            ? props.slotProps.input
+            : {}),
+          startAdornment: (
+            <InputAdornment position="start">{currencySymbol}</InputAdornment>
+          ),
+        },
+      }}
+    />
+  );
+};
+
+export default FormikCurrencyField;

--- a/src/FormikPhoneField/FormikPhoneField.stories.tsx
+++ b/src/FormikPhoneField/FormikPhoneField.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withFormik } from "../test-utils/FormikDecorator";
+import FormikPhoneField from "./FormikPhoneField";
+
+const meta: Meta<typeof FormikPhoneField> = {
+  title: "FormikPhoneField",
+  component: FormikPhoneField,
+  decorators: [
+    withFormik({
+      initialValues: {
+        phone: "",
+      },
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FormikPhoneField>;
+
+export const Default: Story = {
+  args: {
+    name: "phone",
+    label: "Phone Number",
+  },
+};
+
+export const Error: Story = {
+  decorators: [
+    withFormik({
+      initialValues: { phone: "" },
+      initialErrors: { phone: "Phone number is required" },
+      initialTouched: { phone: true },
+    }),
+  ],
+  args: {
+    name: "phone",
+    label: "Phone Number",
+  },
+};
+
+export const PreferredCountries: Story = {
+  args: {
+    name: "phone",
+    label: "Phone Number",
+    defaultCountry: "GB",
+    preferredCountries: ["GB", "US", "CA"],
+  },
+};

--- a/src/FormikPhoneField/FormikPhoneField.test.tsx
+++ b/src/FormikPhoneField/FormikPhoneField.test.tsx
@@ -1,0 +1,231 @@
+import { type Mock } from "vitest";
+import { render } from "@testing-library/react";
+import { useField } from "formik";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  InputAdornment,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
+import FormikPhoneField from "./FormikPhoneField";
+
+vi.mock("formik", () => ({
+  useField: vi.fn(),
+}));
+
+vi.mock("@mui/material", () => ({
+  FormControl: vi.fn(({ children }: any) => children),
+  FormHelperText: vi.fn(() => null),
+  FormLabel: vi.fn(() => null),
+  InputAdornment: vi.fn(({ children }: any) => children),
+  MenuItem: vi.fn(() => null),
+  Select: vi.fn(() => null),
+  TextField: vi.fn(() => null),
+}));
+
+const mockUseField = useField as Mock;
+const MockTextField = TextField as unknown as Mock;
+const MockSelect = Select as unknown as Mock;
+const MockFormControl = FormControl as unknown as Mock;
+const MockFormHelperText = FormHelperText as unknown as Mock;
+const MockFormLabel = FormLabel as unknown as Mock;
+
+const mockHelpers = {
+  setValue: vi.fn(),
+  setTouched: vi.fn(),
+  setError: vi.fn(),
+};
+const defaultField = {
+  name: "phone",
+  value: "",
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+};
+const defaultMeta = {
+  touched: false,
+  error: undefined,
+  initialTouched: false,
+  initialError: undefined,
+  initialValue: "",
+  value: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseField.mockReturnValue([defaultField, defaultMeta, mockHelpers]);
+});
+
+describe("FormikPhoneField", () => {
+  describe("when rendered with a name", () => {
+    it("calls useField with the name", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(mockUseField).toHaveBeenCalledWith("phone");
+    });
+  });
+
+  describe("when rendered with default props", () => {
+    it("passes value and error to TextField", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: "",
+          error: false,
+        }),
+        undefined,
+      );
+    });
+
+    it("renders Select with default country US", () => {
+      render(<FormikPhoneField name="phone" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const adornment = slotProps.input.startAdornment;
+      expect(adornment.props.children.props.value).toBe("US");
+    });
+  });
+
+  describe("when rendered with an existing value", () => {
+    it("detects the country from the dial code", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: "+441234567890" },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikPhoneField name="phone" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const adornment = slotProps.input.startAdornment;
+      expect(adornment.props.children.props.value).toBe("GB");
+    });
+
+    it("displays the formatted local number", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: "+12025551234" },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikPhoneField name="phone" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: "202-555-1234",
+        }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when the phone number changes", () => {
+    it("calls helpers.setValue with the full international format", () => {
+      render(<FormikPhoneField name="phone" />);
+      const onChangeProp = MockTextField.mock.calls[0][0].onChange;
+      onChangeProp({ target: { value: "202-555" } });
+      expect(mockHelpers.setValue).toHaveBeenCalledWith("+1202555");
+    });
+  });
+
+  describe("when the country changes", () => {
+    it("calls helpers.setValue with the new dial code", () => {
+      render(<FormikPhoneField name="phone" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const selectElement = slotProps.input.startAdornment.props.children;
+      const onCountryChange = selectElement.props.onChange;
+      onCountryChange({ target: { value: "GB" } });
+      expect(mockHelpers.setValue).toHaveBeenCalledWith("+44");
+    });
+  });
+
+  describe("when blurred", () => {
+    it("calls helpers.setTouched with true", () => {
+      render(<FormikPhoneField name="phone" />);
+      const onBlurProp = MockTextField.mock.calls[0][0].onBlur;
+      onBlurProp();
+      expect(mockHelpers.setTouched).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("when label is provided", () => {
+    it("renders FormLabel", () => {
+      render(<FormikPhoneField name="phone" label="Phone" />);
+      expect(MockFormLabel).toHaveBeenCalled();
+    });
+  });
+
+  describe("when label is not provided", () => {
+    it("does not render FormLabel", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockFormLabel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when field is touched with an error", () => {
+    beforeEach(() => {
+      mockUseField.mockReturnValue([
+        defaultField,
+        { ...defaultMeta, touched: true, error: "Required" },
+        mockHelpers,
+      ]);
+    });
+
+    it("renders FormControl with error true", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockFormControl).toHaveBeenCalledWith(
+        expect.objectContaining({ error: true }),
+        undefined,
+      );
+    });
+
+    it("renders FormHelperText with the error message", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockFormHelperText).toHaveBeenCalledWith(
+        expect.objectContaining({ children: "Required" }),
+        undefined,
+      );
+    });
+
+    it("passes error true to TextField", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockTextField).toHaveBeenCalledWith(
+        expect.objectContaining({ error: true }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field has no errors", () => {
+    it("renders FormControl with error false", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockFormControl).toHaveBeenCalledWith(
+        expect.objectContaining({ error: false }),
+        undefined,
+      );
+    });
+
+    it("does not render FormHelperText", () => {
+      render(<FormikPhoneField name="phone" />);
+      expect(MockFormHelperText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when defaultCountry is provided", () => {
+    it("uses the specified country as default", () => {
+      render(<FormikPhoneField name="phone" defaultCountry="GB" />);
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const adornment = slotProps.input.startAdornment;
+      expect(adornment.props.children.props.value).toBe("GB");
+    });
+  });
+
+  describe("when preferredCountries is provided", () => {
+    it("renders preferred countries first in the Select", () => {
+      render(
+        <FormikPhoneField name="phone" preferredCountries={["GB", "DE"]} />,
+      );
+      const slotProps = MockTextField.mock.calls[0][0].slotProps;
+      const selectElement = slotProps.input.startAdornment.props.children;
+      const children = selectElement.props.children;
+      expect(children[0].key).toBe("GB");
+      expect(children[1].key).toBe("DE");
+    });
+  });
+});

--- a/src/FormikPhoneField/FormikPhoneField.test.tsx
+++ b/src/FormikPhoneField/FormikPhoneField.test.tsx
@@ -2,6 +2,7 @@ import { type Mock } from "vitest";
 import { render } from "@testing-library/react";
 import { useField } from "formik";
 import {
+  Box,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -12,11 +13,34 @@ import {
 } from "@mui/material";
 import FormikPhoneField from "./FormikPhoneField";
 
+vi.mock("country-codes-list", () => ({
+  all: vi.fn(() => [
+    {
+      countryCode: "US",
+      countryNameEn: "United States",
+      countryCallingCode: "1",
+    },
+    {
+      countryCode: "GB",
+      countryNameEn: "United Kingdom",
+      countryCallingCode: "44",
+    },
+    { countryCode: "DE", countryNameEn: "Germany", countryCallingCode: "49" },
+  ]),
+}));
+
+vi.mock("country-flag-icons/react/3x2", () => ({
+  US: vi.fn(() => null),
+  GB: vi.fn(() => null),
+  DE: vi.fn(() => null),
+}));
+
 vi.mock("formik", () => ({
   useField: vi.fn(),
 }));
 
 vi.mock("@mui/material", () => ({
+  Box: vi.fn(({ children }: any) => children),
   FormControl: vi.fn(({ children }: any) => children),
   FormHelperText: vi.fn(() => null),
   FormLabel: vi.fn(() => null),

--- a/src/FormikPhoneField/FormikPhoneField.tsx
+++ b/src/FormikPhoneField/FormikPhoneField.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Box,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -10,6 +11,8 @@ import {
   TextField,
   type TextFieldProps,
 } from "@mui/material";
+import { all, type CountryData } from "country-codes-list";
+import * as Flags from "country-flag-icons/react/3x2";
 import { useField } from "formik";
 
 type Country = {
@@ -18,23 +21,13 @@ type Country = {
   dialCode: string;
 };
 
-const COUNTRIES: Country[] = [
-  { code: "US", name: "United States", dialCode: "+1" },
-  { code: "GB", name: "United Kingdom", dialCode: "+44" },
-  { code: "CA", name: "Canada", dialCode: "+1" },
-  { code: "AU", name: "Australia", dialCode: "+61" },
-  { code: "DE", name: "Germany", dialCode: "+49" },
-  { code: "FR", name: "France", dialCode: "+33" },
-  { code: "IT", name: "Italy", dialCode: "+39" },
-  { code: "ES", name: "Spain", dialCode: "+34" },
-  { code: "BR", name: "Brazil", dialCode: "+55" },
-  { code: "MX", name: "Mexico", dialCode: "+52" },
-  { code: "IN", name: "India", dialCode: "+91" },
-  { code: "CN", name: "China", dialCode: "+86" },
-  { code: "JP", name: "Japan", dialCode: "+81" },
-  { code: "KR", name: "South Korea", dialCode: "+82" },
-  { code: "NL", name: "Netherlands", dialCode: "+31" },
-];
+const COUNTRIES: Country[] = all()
+  .filter((c: CountryData) => c.countryCallingCode)
+  .map((c: CountryData) => ({
+    code: c.countryCode,
+    name: c.countryNameEn,
+    dialCode: `+${c.countryCallingCode}`,
+  }));
 
 const findCountryByDialCode = (phone: string): Country | undefined => {
   const sorted = [...COUNTRIES].sort(
@@ -133,11 +126,26 @@ const FormikPhoneField = ({
                   disableUnderline
                   sx={{ minWidth: 80 }}
                 >
-                  {sortedCountries.map((country) => (
-                    <MenuItem key={country.code} value={country.code}>
-                      {country.code} {country.dialCode}
-                    </MenuItem>
-                  ))}
+                  {sortedCountries.map((country) => {
+                    const FlagComponent =
+                      Flags[country.code as keyof typeof Flags];
+                    return (
+                      <MenuItem key={country.code} value={country.code}>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1,
+                          }}
+                        >
+                          {FlagComponent && (
+                            <FlagComponent style={{ width: 20, height: 14 }} />
+                          )}
+                          {country.code} {country.dialCode}
+                        </Box>
+                      </MenuItem>
+                    );
+                  })}
                 </Select>
               </InputAdornment>
             ),

--- a/src/FormikPhoneField/FormikPhoneField.tsx
+++ b/src/FormikPhoneField/FormikPhoneField.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  InputAdornment,
+  MenuItem,
+  Select,
+  TextField,
+  type TextFieldProps,
+} from "@mui/material";
+import { useField } from "formik";
+
+type Country = {
+  code: string;
+  name: string;
+  dialCode: string;
+};
+
+const COUNTRIES: Country[] = [
+  { code: "US", name: "United States", dialCode: "+1" },
+  { code: "GB", name: "United Kingdom", dialCode: "+44" },
+  { code: "CA", name: "Canada", dialCode: "+1" },
+  { code: "AU", name: "Australia", dialCode: "+61" },
+  { code: "DE", name: "Germany", dialCode: "+49" },
+  { code: "FR", name: "France", dialCode: "+33" },
+  { code: "IT", name: "Italy", dialCode: "+39" },
+  { code: "ES", name: "Spain", dialCode: "+34" },
+  { code: "BR", name: "Brazil", dialCode: "+55" },
+  { code: "MX", name: "Mexico", dialCode: "+52" },
+  { code: "IN", name: "India", dialCode: "+91" },
+  { code: "CN", name: "China", dialCode: "+86" },
+  { code: "JP", name: "Japan", dialCode: "+81" },
+  { code: "KR", name: "South Korea", dialCode: "+82" },
+  { code: "NL", name: "Netherlands", dialCode: "+31" },
+];
+
+const findCountryByDialCode = (phone: string): Country | undefined => {
+  const sorted = [...COUNTRIES].sort(
+    (a, b) => b.dialCode.length - a.dialCode.length,
+  );
+  return sorted.find((c) => phone.startsWith(c.dialCode));
+};
+
+const formatLocalNumber = (digits: string): string => {
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6, 10)}`;
+};
+
+type Props = {
+  name: string;
+  label?: string;
+  defaultCountry?: string;
+  preferredCountries?: string[];
+} & Omit<
+  TextFieldProps,
+  | "name"
+  | "value"
+  | "onChange"
+  | "onBlur"
+  | "error"
+  | "helperText"
+  | "slotProps"
+>;
+
+const FormikPhoneField = ({
+  name,
+  label,
+  defaultCountry = "US",
+  preferredCountries = [],
+  ...props
+}: Props) => {
+  const [field, meta, helpers] = useField<string>(name);
+  const hasError = meta.touched && Boolean(meta.error);
+
+  const currentValue = field.value ?? "";
+  const matchedCountry = currentValue
+    ? findCountryByDialCode(currentValue)
+    : undefined;
+  const selectedCountry =
+    matchedCountry ??
+    COUNTRIES.find((c) => c.code === defaultCountry) ??
+    COUNTRIES[0]!;
+
+  const localNumber = currentValue.startsWith(selectedCountry.dialCode)
+    ? currentValue.slice(selectedCountry.dialCode.length)
+    : currentValue.replace(/^\+\d*/, "");
+
+  const displayNumber = formatLocalNumber(localNumber);
+
+  const sortedCountries = (() => {
+    if (preferredCountries.length === 0) return COUNTRIES;
+    const preferred = COUNTRIES.filter((c) =>
+      preferredCountries.includes(c.code),
+    );
+    const rest = COUNTRIES.filter((c) => !preferredCountries.includes(c.code));
+    return [...preferred, ...rest];
+  })();
+
+  const handleCountryChange = (newCode: string) => {
+    const newCountry = COUNTRIES.find((c) => c.code === newCode);
+    if (newCountry) {
+      helpers.setValue(`${newCountry.dialCode}${localNumber}`);
+    }
+  };
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const digits = e.target.value.replace(/[^\d]/g, "");
+    helpers.setValue(`${selectedCountry.dialCode}${digits}`);
+  };
+
+  return (
+    <FormControl fullWidth error={hasError}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <TextField
+        {...props}
+        value={displayNumber}
+        onChange={handlePhoneChange}
+        onBlur={() => helpers.setTouched(true)}
+        error={hasError}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Select
+                  value={selectedCountry.code}
+                  onChange={(e) =>
+                    handleCountryChange(e.target.value as string)
+                  }
+                  variant="standard"
+                  disableUnderline
+                  sx={{ minWidth: 80 }}
+                >
+                  {sortedCountries.map((country) => (
+                    <MenuItem key={country.code} value={country.code}>
+                      {country.code} {country.dialCode}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+      {hasError && <FormHelperText>{meta.error}</FormHelperText>}
+    </FormControl>
+  );
+};
+
+export default FormikPhoneField;

--- a/src/FormikRichTextField/FormikRichTextField.stories.tsx
+++ b/src/FormikRichTextField/FormikRichTextField.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withFormik } from "../test-utils/FormikDecorator";
+import FormikRichTextField from "./FormikRichTextField";
+
+const meta: Meta<typeof FormikRichTextField> = {
+  title: "FormikRichTextField",
+  component: FormikRichTextField,
+  decorators: [
+    withFormik({
+      initialValues: {
+        content: "",
+      },
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FormikRichTextField>;
+
+export const Default: Story = {
+  args: {
+    name: "content",
+    label: "Content",
+    placeholder: "Start typing...",
+  },
+};
+
+export const Error: Story = {
+  decorators: [
+    withFormik({
+      initialValues: { content: "" },
+      initialErrors: { content: "Content is required" },
+      initialTouched: { content: true },
+    }),
+  ],
+  args: {
+    name: "content",
+    label: "Content",
+    placeholder: "Start typing...",
+  },
+};
+
+export const CustomToolbar: Story = {
+  args: {
+    name: "content",
+    label: "Simple Editor",
+    placeholder: "Bold and italic only...",
+    toolbar: ["bold", "italic"],
+  },
+};

--- a/src/FormikRichTextField/FormikRichTextField.test.tsx
+++ b/src/FormikRichTextField/FormikRichTextField.test.tsx
@@ -1,0 +1,332 @@
+import { type Mock } from "vitest";
+import { render } from "@testing-library/react";
+import { useField } from "formik";
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+} from "@mui/material";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import LinkExtension from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import FormikRichTextField from "./FormikRichTextField";
+
+vi.mock("formik", () => ({
+  useField: vi.fn(),
+}));
+
+vi.mock("@mui/material", () => ({
+  Box: vi.fn(({ children }: any) => children),
+  FormControl: vi.fn(({ children }: any) => children),
+  FormHelperText: vi.fn(() => null),
+  FormLabel: vi.fn(() => null),
+  IconButton: vi.fn(() => null),
+}));
+
+vi.mock("@mui/icons-material", () => ({
+  FormatBold: vi.fn(() => null),
+  FormatItalic: vi.fn(() => null),
+  Link: vi.fn(() => null),
+  FormatListBulleted: vi.fn(() => null),
+  FormatListNumbered: vi.fn(() => null),
+}));
+
+vi.mock("@tiptap/react", () => ({
+  useEditor: vi.fn(),
+  EditorContent: vi.fn(() => null),
+}));
+
+vi.mock("@tiptap/starter-kit", () => ({
+  default: "StarterKit",
+}));
+
+vi.mock("@tiptap/extension-link", () => ({
+  default: {
+    configure: vi.fn(() => "LinkExtension"),
+  },
+}));
+
+vi.mock("@tiptap/extension-placeholder", () => ({
+  default: {
+    configure: vi.fn(() => "PlaceholderExtension"),
+  },
+}));
+
+const mockUseField = useField as Mock;
+const MockFormControl = FormControl as unknown as Mock;
+const MockFormHelperText = FormHelperText as unknown as Mock;
+const MockFormLabel = FormLabel as unknown as Mock;
+const MockIconButton = IconButton as unknown as Mock;
+const mockUseEditor = useEditor as Mock;
+const MockEditorContent = EditorContent as unknown as Mock;
+
+const mockChain = {
+  focus: vi.fn(),
+  toggleBold: vi.fn(),
+  toggleItalic: vi.fn(),
+  toggleBulletList: vi.fn(),
+  toggleOrderedList: vi.fn(),
+  setLink: vi.fn(),
+  unsetLink: vi.fn(),
+  run: vi.fn(),
+  setContent: vi.fn(),
+};
+
+// Make chain methods return the chain for chaining
+mockChain.focus.mockReturnValue(mockChain);
+mockChain.toggleBold.mockReturnValue(mockChain);
+mockChain.toggleItalic.mockReturnValue(mockChain);
+mockChain.toggleBulletList.mockReturnValue(mockChain);
+mockChain.toggleOrderedList.mockReturnValue(mockChain);
+mockChain.setLink.mockReturnValue(mockChain);
+mockChain.unsetLink.mockReturnValue(mockChain);
+
+const mockEditor = {
+  getHTML: vi.fn(() => ""),
+  isActive: vi.fn(() => false),
+  chain: vi.fn(() => mockChain),
+  commands: {
+    setContent: vi.fn(),
+  },
+};
+
+const mockHelpers = {
+  setValue: vi.fn(),
+  setTouched: vi.fn(),
+  setError: vi.fn(),
+};
+const defaultField = {
+  name: "content",
+  value: "",
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+};
+const defaultMeta = {
+  touched: false,
+  error: undefined,
+  initialTouched: false,
+  initialError: undefined,
+  initialValue: "",
+  value: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseField.mockReturnValue([defaultField, defaultMeta, mockHelpers]);
+  mockUseEditor.mockReturnValue(mockEditor);
+  mockChain.focus.mockReturnValue(mockChain);
+  mockChain.toggleBold.mockReturnValue(mockChain);
+  mockChain.toggleItalic.mockReturnValue(mockChain);
+  mockChain.toggleBulletList.mockReturnValue(mockChain);
+  mockChain.toggleOrderedList.mockReturnValue(mockChain);
+  mockChain.setLink.mockReturnValue(mockChain);
+  mockChain.unsetLink.mockReturnValue(mockChain);
+  mockEditor.isActive.mockReturnValue(false);
+  mockEditor.getHTML.mockReturnValue("");
+});
+
+describe("FormikRichTextField", () => {
+  describe("when rendered with a name", () => {
+    it("calls useField with the name", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(mockUseField).toHaveBeenCalledWith("content");
+    });
+  });
+
+  describe("when rendered with default props", () => {
+    it("calls useEditor with extensions and configuration", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(mockUseEditor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "",
+        }),
+      );
+    });
+
+    it("renders EditorContent with the editor", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockEditorContent).toHaveBeenCalledWith(
+        expect.objectContaining({ editor: mockEditor }),
+        undefined,
+      );
+    });
+
+    it("renders all toolbar buttons by default", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockIconButton).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("when rendered with a custom toolbar", () => {
+    it("renders only the specified toolbar buttons", () => {
+      render(
+        <FormikRichTextField name="content" toolbar={["bold", "italic"]} />,
+      );
+      expect(MockIconButton).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when the editor content updates", () => {
+    it("calls helpers.setValue with the HTML", () => {
+      render(<FormikRichTextField name="content" />);
+      const editorConfig = mockUseEditor.mock.calls[0][0];
+      mockEditor.getHTML.mockReturnValue("<p>Hello</p>");
+      editorConfig.onUpdate({ editor: mockEditor });
+      expect(mockHelpers.setValue).toHaveBeenCalledWith("<p>Hello</p>");
+    });
+  });
+
+  describe("when the editor loses focus", () => {
+    it("calls helpers.setTouched with true", () => {
+      render(<FormikRichTextField name="content" />);
+      const editorConfig = mockUseEditor.mock.calls[0][0];
+      editorConfig.onBlur();
+      expect(mockHelpers.setTouched).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("when bold button is clicked", () => {
+    it("toggles bold on the editor", () => {
+      render(<FormikRichTextField name="content" />);
+      const boldButton = MockIconButton.mock.calls.find(
+        (call: unknown[]) => call[0].children?.type === vi.mocked(() => null),
+      );
+      // Find the bold button by checking onClick calls
+      const boldOnClick = MockIconButton.mock.calls[0][0].onClick;
+      boldOnClick();
+      expect(mockEditor.chain).toHaveBeenCalled();
+      expect(mockChain.focus).toHaveBeenCalled();
+      expect(mockChain.toggleBold).toHaveBeenCalled();
+      expect(mockChain.run).toHaveBeenCalled();
+    });
+  });
+
+  describe("when italic button is clicked", () => {
+    it("toggles italic on the editor", () => {
+      render(<FormikRichTextField name="content" />);
+      const italicOnClick = MockIconButton.mock.calls[1][0].onClick;
+      italicOnClick();
+      expect(mockEditor.chain).toHaveBeenCalled();
+      expect(mockChain.focus).toHaveBeenCalled();
+      expect(mockChain.toggleItalic).toHaveBeenCalled();
+      expect(mockChain.run).toHaveBeenCalled();
+    });
+  });
+
+  describe("when link button is clicked and link is not active", () => {
+    it("prompts for URL and sets link", () => {
+      const promptSpy = vi
+        .spyOn(window, "prompt")
+        .mockReturnValue("https://example.com");
+      render(<FormikRichTextField name="content" />);
+      const linkOnClick = MockIconButton.mock.calls[2][0].onClick;
+      linkOnClick();
+      expect(promptSpy).toHaveBeenCalledWith("Enter URL");
+      expect(mockChain.setLink).toHaveBeenCalledWith({
+        href: "https://example.com",
+      });
+      expect(mockChain.run).toHaveBeenCalled();
+      promptSpy.mockRestore();
+    });
+  });
+
+  describe("when link button is clicked and link is active", () => {
+    it("unsets the link", () => {
+      mockEditor.isActive.mockImplementation((type: string) => type === "link");
+      render(<FormikRichTextField name="content" />);
+      const linkOnClick = MockIconButton.mock.calls[2][0].onClick;
+      linkOnClick();
+      expect(mockChain.unsetLink).toHaveBeenCalled();
+      expect(mockChain.run).toHaveBeenCalled();
+    });
+  });
+
+  describe("when bullet list button is clicked", () => {
+    it("toggles bullet list on the editor", () => {
+      render(<FormikRichTextField name="content" />);
+      const bulletOnClick = MockIconButton.mock.calls[3][0].onClick;
+      bulletOnClick();
+      expect(mockChain.toggleBulletList).toHaveBeenCalled();
+      expect(mockChain.run).toHaveBeenCalled();
+    });
+  });
+
+  describe("when ordered list button is clicked", () => {
+    it("toggles ordered list on the editor", () => {
+      render(<FormikRichTextField name="content" />);
+      const orderedOnClick = MockIconButton.mock.calls[4][0].onClick;
+      orderedOnClick();
+      expect(mockChain.toggleOrderedList).toHaveBeenCalled();
+      expect(mockChain.run).toHaveBeenCalled();
+    });
+  });
+
+  describe("when label is provided", () => {
+    it("renders FormLabel", () => {
+      render(<FormikRichTextField name="content" label="Content" />);
+      expect(MockFormLabel).toHaveBeenCalled();
+    });
+  });
+
+  describe("when label is not provided", () => {
+    it("does not render FormLabel", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockFormLabel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when field is touched with an error", () => {
+    beforeEach(() => {
+      mockUseField.mockReturnValue([
+        defaultField,
+        { ...defaultMeta, touched: true, error: "Required" },
+        mockHelpers,
+      ]);
+    });
+
+    it("renders FormControl with error true", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockFormControl).toHaveBeenCalledWith(
+        expect.objectContaining({ error: true }),
+        undefined,
+      );
+    });
+
+    it("renders FormHelperText with the error message", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockFormHelperText).toHaveBeenCalledWith(
+        expect.objectContaining({ children: "Required" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when field has no errors", () => {
+    it("renders FormControl with error false", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockFormControl).toHaveBeenCalledWith(
+        expect.objectContaining({ error: false }),
+        undefined,
+      );
+    });
+
+    it("does not render FormHelperText", () => {
+      render(<FormikRichTextField name="content" />);
+      expect(MockFormHelperText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when placeholder is provided", () => {
+    it("configures Placeholder extension with the placeholder text", () => {
+      render(
+        <FormikRichTextField name="content" placeholder="Start typing..." />,
+      );
+      expect(
+        (Placeholder as unknown as { configure: Mock }).configure,
+      ).toHaveBeenCalledWith({ placeholder: "Start typing..." });
+    });
+  });
+});

--- a/src/FormikRichTextField/FormikRichTextField.tsx
+++ b/src/FormikRichTextField/FormikRichTextField.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+} from "@mui/material";
+import {
+  FormatBold,
+  FormatItalic,
+  Link,
+  FormatListBulleted,
+  FormatListNumbered,
+} from "@mui/icons-material";
+import { useField } from "formik";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import LinkExtension from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+
+type ToolbarAction = "bold" | "italic" | "link" | "bulletList" | "orderedList";
+
+type Props = {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  toolbar?: ToolbarAction[];
+};
+
+const defaultToolbar: ToolbarAction[] = [
+  "bold",
+  "italic",
+  "link",
+  "bulletList",
+  "orderedList",
+];
+
+const FormikRichTextField = ({
+  name,
+  label,
+  placeholder,
+  toolbar = defaultToolbar,
+}: Props) => {
+  const [field, meta, helpers] = useField<string>(name);
+  const hasError = meta.touched && Boolean(meta.error);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      LinkExtension.configure({ openOnClick: false }),
+      Placeholder.configure({ placeholder: placeholder ?? "" }),
+    ],
+    content: field.value ?? "",
+    onUpdate: ({ editor }) => {
+      helpers.setValue(editor.getHTML());
+    },
+    onBlur: () => {
+      helpers.setTouched(true);
+    },
+  });
+
+  useEffect(() => {
+    if (editor && field.value !== editor.getHTML()) {
+      editor.commands.setContent(field.value ?? "");
+    }
+  }, [field.value, editor]);
+
+  const handleToggleBold = () => {
+    editor?.chain().focus().toggleBold().run();
+  };
+
+  const handleToggleItalic = () => {
+    editor?.chain().focus().toggleItalic().run();
+  };
+
+  const handleToggleLink = () => {
+    if (editor?.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+    } else {
+      const url = window.prompt("Enter URL");
+      if (url) {
+        editor?.chain().focus().setLink({ href: url }).run();
+      }
+    }
+  };
+
+  const handleToggleBulletList = () => {
+    editor?.chain().focus().toggleBulletList().run();
+  };
+
+  const handleToggleOrderedList = () => {
+    editor?.chain().focus().toggleOrderedList().run();
+  };
+
+  return (
+    <FormControl fullWidth error={hasError}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <Box
+        sx={(theme) => ({
+          border: `1px solid ${hasError ? theme.palette.error.main : theme.palette.divider}`,
+          borderRadius: 1,
+          "&:hover": {
+            borderColor: hasError
+              ? theme.palette.error.main
+              : theme.palette.text.primary,
+          },
+          "&:focus-within": {
+            borderColor: hasError
+              ? theme.palette.error.main
+              : theme.palette.primary.main,
+            borderWidth: 2,
+          },
+        })}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            gap: 0.5,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            p: 0.5,
+          }}
+        >
+          {toolbar.includes("bold") && (
+            <IconButton
+              size="small"
+              onClick={handleToggleBold}
+              color={editor?.isActive("bold") ? "primary" : "default"}
+            >
+              <FormatBold />
+            </IconButton>
+          )}
+          {toolbar.includes("italic") && (
+            <IconButton
+              size="small"
+              onClick={handleToggleItalic}
+              color={editor?.isActive("italic") ? "primary" : "default"}
+            >
+              <FormatItalic />
+            </IconButton>
+          )}
+          {toolbar.includes("link") && (
+            <IconButton
+              size="small"
+              onClick={handleToggleLink}
+              color={editor?.isActive("link") ? "primary" : "default"}
+            >
+              <Link />
+            </IconButton>
+          )}
+          {toolbar.includes("bulletList") && (
+            <IconButton
+              size="small"
+              onClick={handleToggleBulletList}
+              color={editor?.isActive("bulletList") ? "primary" : "default"}
+            >
+              <FormatListBulleted />
+            </IconButton>
+          )}
+          {toolbar.includes("orderedList") && (
+            <IconButton
+              size="small"
+              onClick={handleToggleOrderedList}
+              color={editor?.isActive("orderedList") ? "primary" : "default"}
+            >
+              <FormatListNumbered />
+            </IconButton>
+          )}
+        </Box>
+        <Box sx={{ p: 1, "& .tiptap": { outline: "none", minHeight: 100 } }}>
+          <EditorContent editor={editor} />
+        </Box>
+      </Box>
+      {hasError && <FormHelperText>{meta.error}</FormHelperText>}
+    </FormControl>
+  );
+};
+
+export default FormikRichTextField;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export { default as FormikFileUpload } from "./FormikFileUpload/FormikFileUpload
 export { default as FormikChipInput } from "./FormikChipInput/FormikChipInput";
 export { default as FormikRadioCards } from "./FormikRadioCards/FormikRadioCards";
 export { default as FormikSearchField } from "./FormikSearchField/FormikSearchField";
+export { default as FormikCurrencyField } from "./FormikCurrencyField/FormikCurrencyField";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export { default as FormikRadioCards } from "./FormikRadioCards/FormikRadioCards
 export { default as FormikSearchField } from "./FormikSearchField/FormikSearchField";
 export { default as FormikCurrencyField } from "./FormikCurrencyField/FormikCurrencyField";
 export { default as FormikPhoneField } from "./FormikPhoneField/FormikPhoneField";
+export { default as FormikRichTextField } from "./FormikRichTextField/FormikRichTextField";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export { default as FormikChipInput } from "./FormikChipInput/FormikChipInput";
 export { default as FormikRadioCards } from "./FormikRadioCards/FormikRadioCards";
 export { default as FormikSearchField } from "./FormikSearchField/FormikSearchField";
 export { default as FormikCurrencyField } from "./FormikCurrencyField/FormikCurrencyField";
+export { default as FormikPhoneField } from "./FormikPhoneField/FormikPhoneField";


### PR DESCRIPTION
## Summary

- **FormikPhoneField** — Phone input with country code selector, 15 built-in countries, and international format storage (`+1234567890`). Closes #10
- **FormikCurrencyField** — Numeric input with `Intl.NumberFormat` formatting, currency symbol adornment, configurable locale/precision. Closes #11
- **FormikRichTextField** — Minimal rich text editor using Tiptap with bold/italic/link/list toolbar, MUI-styled, HTML storage. Closes #12

All three components follow the established patterns: `"use client"` directive, `useField` with `helpers.setValue`/`helpers.setTouched`, `FormControl`/`FormHelperText` error display, colocated tests and stories.

## Test plan

- [x] All 1204 tests pass (`pnpm test`)
- [x] TypeScript type-checking passes (`npx tsc --noEmit`)
- [ ] Verify Storybook renders correctly for all three new components
- [ ] Verify FormikPhoneField country selection and dial code formatting
- [ ] Verify FormikCurrencyField thousand separators and decimal precision
- [ ] Verify FormikRichTextField toolbar actions and HTML output