### PR TITLE
(fix) Use InputLabel instead of FormLabel in FormikSelect

### DIFF
--- a/src/FormikSelect/FormikSelect.test.tsx
+++ b/src/FormikSelect/FormikSelect.test.tsx
@@ -5,7 +5,7 @@ import {
   Select,
   MenuItem,
   FormControl,
-  FormLabel,
+  InputLabel,
   FormHelperText,
 } from "@mui/material";
 import FormikSelect from "./FormikSelect";
@@ -18,7 +18,7 @@ vi.mock("@mui/material", () => ({
   Select: vi.fn(({ children }: any) => children),
   MenuItem: vi.fn(() => null),
   FormControl: vi.fn(({ children }: any) => children),
-  FormLabel: vi.fn(() => null),
+  InputLabel: vi.fn(() => null),
   FormHelperText: vi.fn(() => null),
 }));
 
@@ -26,7 +26,7 @@ const mockUseField = useField as Mock;
 const MockSelect = Select as unknown as Mock;
 const MockMenuItem = MenuItem as unknown as Mock;
 const MockFormControl = FormControl as unknown as Mock;
-const MockFormLabel = FormLabel as unknown as Mock;
+const MockInputLabel = InputLabel as unknown as Mock;
 const MockFormHelperText = FormHelperText as unknown as Mock;
 
 const defaultField = {
@@ -92,16 +92,16 @@ describe("FormikSelect", () => {
   });
 
   describe("when label is provided", () => {
-    it("renders FormLabel", () => {
+    it("renders InputLabel", () => {
       render(<FormikSelect name="fruit" label="Fruit" options={options} />);
-      expect(MockFormLabel).toHaveBeenCalled();
+      expect(MockInputLabel).toHaveBeenCalled();
     });
   });
 
   describe("when no label is provided", () => {
-    it("does not render FormLabel", () => {
+    it("does not render InputLabel", () => {
       render(<FormikSelect name="fruit" options={options} />);
-      expect(MockFormLabel).not.toHaveBeenCalled();
+      expect(MockInputLabel).not.toHaveBeenCalled();
     });
   });
 

--- a/src/FormikSelect/FormikSelect.tsx
+++ b/src/FormikSelect/FormikSelect.tsx
@@ -3,7 +3,7 @@
 import {
   FormControl,
   FormHelperText,
-  FormLabel,
+  InputLabel,
   MenuItem,
   Select,
   type SelectProps,
@@ -22,8 +22,8 @@ const FormikSelect = ({ name, label, options, ...props }: Props) => {
 
   return (
     <FormControl fullWidth error={hasError}>
-      {label && <FormLabel>{label}</FormLabel>}
-      <Select {...field} {...props}>
+      {label && <InputLabel>{label}</InputLabel>}
+      <Select {...field} {...props} label={label}>
         {options.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             {option.label}


### PR DESCRIPTION
Use InputLabel instead of FormLabel in FormikSelect