### PR TITLE
Add clear button to FormikFileUpload and FormikImageUpload

### DIFF
--- a/.changeset/clear-button-uploads.md
+++ b/.changeset/clear-button-uploads.md
@@ -1,0 +1,8 @@
+---
+"formik-mui-fields": minor
+---
+
+Add a clear button to FormikFileUpload and FormikImageUpload
+
+- `FormikFileUpload` now renders a clear `IconButton` (only when a file/files are selected) that resets the field to `null` for single uploads or `[]` for multiple, sets the field touched, and clears the native input.
+- `FormikImageUpload` now renders a clear `IconButton` over the dropzone (only when an image is present) that resets the value to `""` and clears the internal crop source, without re-opening the file picker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # formik-mui-fields
 
+## 0.4.0
+
+### Minor Changes
+
+- - Add onChange property to all components
+  - Add story example for Form usage
+
 ## 0.3.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formik-mui-fields",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/FormikFileUpload/FormikFileUpload.stories.tsx
+++ b/src/FormikFileUpload/FormikFileUpload.stories.tsx
@@ -56,3 +56,19 @@ export const Multiple: Story = {
     multiple: true,
   },
 };
+
+export const WithValue: Story = {
+  decorators: [
+    withFormik({
+      initialValues: {
+        document: new File(["content"], "report.pdf", {
+          type: "application/pdf",
+        }),
+      },
+    }),
+  ],
+  args: {
+    name: "document",
+    label: "Upload document",
+  },
+};

--- a/src/FormikFileUpload/FormikFileUpload.test.tsx
+++ b/src/FormikFileUpload/FormikFileUpload.test.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   FormControl,
   FormHelperText,
+  IconButton,
   Typography,
 } from "@mui/material";
 import FormikFileUpload from "./FormikFileUpload";
@@ -19,7 +20,12 @@ vi.mock("@mui/material", () => ({
   Button: vi.fn(({ children }: any) => children ?? null),
   FormControl: vi.fn(({ children }: any) => children),
   FormHelperText: vi.fn(() => null),
+  IconButton: vi.fn(() => null),
   Typography: vi.fn(() => null),
+}));
+
+vi.mock("@mui/icons-material", () => ({
+  Clear: vi.fn(() => null),
 }));
 
 const mockUseField = useField as Mock;
@@ -27,6 +33,7 @@ const MockBox = Box as unknown as Mock;
 const MockButton = Button as unknown as Mock;
 const MockFormControl = FormControl as unknown as Mock;
 const MockFormHelperText = FormHelperText as unknown as Mock;
+const MockIconButton = IconButton as unknown as Mock;
 const MockTypography = Typography as unknown as Mock;
 
 const mockHelpers = {
@@ -213,6 +220,106 @@ describe("FormikFileUpload", () => {
         }),
         undefined,
       );
+    });
+  });
+
+  describe("when the field value is null", () => {
+    it("does not render the clear IconButton", () => {
+      render(<FormikFileUpload name="document" />);
+      expect(MockIconButton).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the field value is an empty array", () => {
+    it("does not render the clear IconButton", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: [] },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="documents" multiple />);
+      expect(MockIconButton).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a single file value is present", () => {
+    it("renders the clear IconButton with an aria-label", () => {
+      const file = new File(["content"], "test.pdf", {
+        type: "application/pdf",
+      });
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: file },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="document" />);
+      expect(MockIconButton).toHaveBeenCalledWith(
+        expect.objectContaining({ "aria-label": "Clear file" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when a multiple file value is present", () => {
+    it("renders the clear IconButton", () => {
+      const files = [new File(["a"], "file1.pdf", { type: "application/pdf" })];
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: files },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="documents" multiple />);
+      expect(MockIconButton).toHaveBeenCalledWith(
+        expect.objectContaining({ "aria-label": "Clear file" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when the clear IconButton onClick is invoked for a single field", () => {
+    it("calls helpers.setValue with null", () => {
+      const file = new File(["content"], "test.pdf", {
+        type: "application/pdf",
+      });
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: file },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="document" />);
+      const onClick = MockIconButton.mock.calls[0][0].onClick;
+      onClick();
+      expect(mockHelpers.setValue).toHaveBeenCalledWith(null);
+    });
+
+    it("calls helpers.setTouched with true", () => {
+      const file = new File(["content"], "test.pdf", {
+        type: "application/pdf",
+      });
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: file },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="document" />);
+      const onClick = MockIconButton.mock.calls[0][0].onClick;
+      onClick();
+      expect(mockHelpers.setTouched).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("when the clear IconButton onClick is invoked for a multiple field", () => {
+    it("calls helpers.setValue with an empty array", () => {
+      const files = [new File(["a"], "file1.pdf", { type: "application/pdf" })];
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: files },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikFileUpload name="documents" multiple />);
+      const onClick = MockIconButton.mock.calls[0][0].onClick;
+      onClick();
+      expect(mockHelpers.setValue).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/src/FormikFileUpload/FormikFileUpload.tsx
+++ b/src/FormikFileUpload/FormikFileUpload.tsx
@@ -103,7 +103,11 @@ const FormikFileUpload = ({
           {getDisplayText()}
         </Typography>
         {hasValue && (
-          <IconButton aria-label="Clear file" onClick={handleClear} size="small">
+          <IconButton
+            aria-label="Clear file"
+            onClick={handleClear}
+            size="small"
+          >
             <Clear fontSize="small" />
           </IconButton>
         )}

--- a/src/FormikFileUpload/FormikFileUpload.tsx
+++ b/src/FormikFileUpload/FormikFileUpload.tsx
@@ -5,8 +5,10 @@ import {
   Button,
   FormControl,
   FormHelperText,
+  IconButton,
   Typography,
 } from "@mui/material";
+import { Clear } from "@mui/icons-material";
 import { useField } from "formik";
 import { useCallback, useRef } from "react";
 
@@ -63,6 +65,18 @@ const FormikFileUpload = ({
     [helpers, maxSize, multiple],
   );
 
+  const handleClear = useCallback(() => {
+    helpers.setValue(multiple ? [] : null);
+    helpers.setTouched(true);
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  }, [helpers, multiple]);
+
+  const hasValue = Array.isArray(field.value)
+    ? field.value.length > 0
+    : Boolean(field.value);
+
   const getDisplayText = (): string => {
     if (!field.value) return "No file selected";
     if (Array.isArray(field.value)) {
@@ -88,6 +102,11 @@ const FormikFileUpload = ({
         <Typography variant="body2" color="text.secondary">
           {getDisplayText()}
         </Typography>
+        {hasValue && (
+          <IconButton aria-label="Clear file" onClick={handleClear} size="small">
+            <Clear fontSize="small" />
+          </IconButton>
+        )}
       </Box>
       <input
         ref={inputRef}

--- a/src/FormikImageUpload/FormikImageUpload.stories.tsx
+++ b/src/FormikImageUpload/FormikImageUpload.stories.tsx
@@ -43,6 +43,20 @@ export const CropSingleAspect: Story = {
   },
 };
 
+const SAMPLE_IMAGE =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120"><rect width="240" height="120" fill="#90caf9"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#0d47a1">Sample image</text></svg>',
+  );
+
+export const WithValue: Story = {
+  decorators: [withFormik({ initialValues: { avatar: SAMPLE_IMAGE } })],
+  args: {
+    name: "avatar",
+    label: "Upload avatar",
+  },
+};
+
 export const Error: Story = {
   decorators: [
     withFormik({

--- a/src/FormikImageUpload/FormikImageUpload.test.tsx
+++ b/src/FormikImageUpload/FormikImageUpload.test.tsx
@@ -1,7 +1,13 @@
 import { type Mock } from "vitest";
 import { render } from "@testing-library/react";
 import { useField } from "formik";
-import { Box, FormControl, FormHelperText, Typography } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import FormikImageUpload from "./FormikImageUpload";
 
 vi.mock("formik", () => ({
@@ -12,7 +18,12 @@ vi.mock("@mui/material", () => ({
   Box: vi.fn(({ children }: any) => children ?? null),
   FormControl: vi.fn(({ children }: any) => children),
   FormHelperText: vi.fn(() => null),
+  IconButton: vi.fn(() => null),
   Typography: vi.fn(() => null),
+}));
+
+vi.mock("@mui/icons-material", () => ({
+  Clear: vi.fn(() => null),
 }));
 
 vi.mock("../CropDialog/CropDialog", () => ({ default: vi.fn(() => null) }));
@@ -23,6 +34,7 @@ const mockUseField = useField as Mock;
 const MockBox = Box as unknown as Mock;
 const MockFormControl = FormControl as unknown as Mock;
 const MockFormHelperText = FormHelperText as unknown as Mock;
+const MockIconButton = IconButton as unknown as Mock;
 const MockTypography = Typography as unknown as Mock;
 const MockCropDialog = CropDialog as unknown as Mock;
 
@@ -160,6 +172,45 @@ describe("FormikImageUpload", () => {
     it("does not render FormHelperText", () => {
       render(<FormikImageUpload name="avatar" />);
       expect(MockFormHelperText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when no image is present", () => {
+    it("does not render the clear button", () => {
+      render(<FormikImageUpload name="avatar" />);
+      expect(MockIconButton).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an image is present", () => {
+    it("renders the clear button", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: "blob:uploaded" },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikImageUpload name="avatar" />);
+      expect(MockIconButton).toHaveBeenCalledWith(
+        expect.objectContaining({ "aria-label": "Clear image" }),
+        undefined,
+      );
+    });
+  });
+
+  describe("when the clear button is clicked", () => {
+    it("prevents default, stops propagation, and clears the value", () => {
+      mockUseField.mockReturnValue([
+        { ...defaultField, value: "blob:uploaded" },
+        defaultMeta,
+        mockHelpers,
+      ]);
+      render(<FormikImageUpload name="avatar" />);
+      const onClick = MockIconButton.mock.calls[0][0].onClick;
+      const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+      onClick(event);
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
+      expect(mockHelpers.setValue).toHaveBeenCalledWith("");
     });
   });
 

--- a/src/FormikImageUpload/FormikImageUpload.tsx
+++ b/src/FormikImageUpload/FormikImageUpload.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Box, FormControl, FormHelperText, Typography } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import { Clear } from "@mui/icons-material";
 import { useField } from "formik";
 import { useCallback, useState } from "react";
 
@@ -54,6 +61,16 @@ const FormikImageUpload = ({
     setRawImageSrc(null);
   }, []);
 
+  const handleClear = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      helpers.setValue("");
+      setRawImageSrc(null);
+    },
+    [helpers],
+  );
+
   return (
     <FormControl fullWidth error={hasError}>
       {label && (
@@ -67,6 +84,7 @@ const FormikImageUpload = ({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          position: "relative",
           width: "100%",
           height,
           border: "2px dashed",
@@ -92,6 +110,22 @@ const FormikImageUpload = ({
           hidden
           onChange={handleFileChange}
         />
+        {field.value && (
+          <IconButton
+            aria-label="Clear image"
+            size="small"
+            onClick={handleClear}
+            sx={{
+              position: "absolute",
+              top: 4,
+              right: 4,
+              bgcolor: "background.paper",
+              "&:hover": { bgcolor: "background.paper" },
+            }}
+          >
+            <Clear fontSize="small" />
+          </IconButton>
+        )}
       </Box>
       {hasError && <FormHelperText>{meta.error}</FormHelperText>}
 


### PR DESCRIPTION
Closes #17.

## Summary
Adds a one-click clear button to both upload components so users can reset the selected file(s)/image without re-opening the file picker.

- **FormikFileUpload** — renders a clear `IconButton` (aria-label `Clear file`) only when a value is present; clears to `null` (single) or `[]` (multiple), sets the field touched, and clears the native input ref.
- **FormikImageUpload** — renders an absolutely-positioned clear `IconButton` (aria-label `Clear image`) over the dropzone only when an image is present; resets the value to `""` and clears internal crop state. Calls `preventDefault()`/`stopPropagation()` so the `<Box component="label">` dropzone does not re-open the picker.

Both keep `"use client"` and the `FormControl` + `FormHelperText` error pattern; no change to the public props surface or `src/index.ts`.

## Tests & tooling
- Updated `FormikFileUpload.test.tsx` and `FormikImageUpload.test.tsx` following the repo's mock-everything philosophy (mocked `IconButton` / `@mui/icons-material`, extracted `onClick` instead of `fireEvent`).
- Added `WithValue` stories to both components so the clear button is visible in Storybook.
- Added a **minor** changeset.
- `npx tsc --noEmit` passes; `pnpm test` green (228 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)